### PR TITLE
Add WinUI interop and Windows Bluetooth skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,4 @@ Run `just clean` afterwards to restore things to original state for mobile app b
 
 Experimental WinUI support is available. See [BUILD_WINDOWS.md](BUILD_WINDOWS.md) for
 instructions on compiling the Swift core as a library and creating a WinUI front-end in C#.
+The `WinUIExample` folder contains a minimal project demonstrating the C# bindings.

--- a/WinUIExample/App.xaml
+++ b/WinUIExample/App.xaml
@@ -1,0 +1,5 @@
+<Application
+    x:Class="WinUIExample.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+</Application>

--- a/WinUIExample/App.xaml.cs
+++ b/WinUIExample/App.xaml.cs
@@ -1,0 +1,17 @@
+using Microsoft.UI.Xaml;
+using System.Runtime.InteropServices;
+
+namespace WinUIExample
+{
+    public partial class App : Application
+    {
+        [DllImport("bitchat.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void Bitchat_Initialize();
+
+        public App()
+        {
+            this.InitializeComponent();
+            Bitchat_Initialize();
+        }
+    }
+}

--- a/WinUIExample/MainWindow.xaml
+++ b/WinUIExample/MainWindow.xaml
@@ -1,0 +1,10 @@
+<Window
+    x:Class="WinUIExample.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="BitChat" Height="300" Width="300">
+    <StackPanel Margin="20">
+        <TextBox x:Name="MessageBox"/>
+        <Button Content="Send" Click="OnSend" Margin="0,10,0,0"/>
+    </StackPanel>
+</Window>

--- a/WinUIExample/MainWindow.xaml.cs
+++ b/WinUIExample/MainWindow.xaml.cs
@@ -1,0 +1,23 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System.Runtime.InteropServices;
+
+namespace WinUIExample
+{
+    public sealed partial class MainWindow : Window
+    {
+        [DllImport("bitchat.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void Bitchat_SendMessage(string text);
+
+        public MainWindow()
+        {
+            this.InitializeComponent();
+        }
+
+        private void OnSend(object sender, RoutedEventArgs e)
+        {
+            Bitchat_SendMessage(MessageBox.Text);
+            MessageBox.Text = string.Empty;
+        }
+    }
+}

--- a/WinUIExample/README.md
+++ b/WinUIExample/README.md
@@ -1,0 +1,12 @@
+# WinUI Example
+
+This folder contains a minimal WinUI 3 front end that calls the Swift
+`ChatViewModel` via P/Invoke.
+
+Build steps:
+1. Build the Swift library in `Release` mode on Windows:
+   ```powershell
+   swift build -c Release
+   ```
+   Copy the resulting `bitchat.dll` into this project's folder.
+2. Open `WinUIExample.csproj` in Visual Studio and build.

--- a/WinUIExample/WinUIExample.csproj
+++ b/WinUIExample/WinUIExample.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <UseWinUI>true</UseWinUI>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/bitchat/Services/WindowsBluetoothMeshService.swift
+++ b/bitchat/Services/WindowsBluetoothMeshService.swift
@@ -1,14 +1,72 @@
 #if os(Windows)
 import Foundation
 import WinSDK
+import WindowsDevicesBluetooth
+import WindowsDevicesBluetoothAdvertisement
+import WindowsStorageStreams
 
 class WindowsBluetoothMeshService: NSObject, MeshServiceProtocol {
     weak var delegate: BitchatDelegate?
     var myPeerID: String = UUID().uuidString
 
+    private var watcher: Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcher?
+    private var publisher: Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementPublisher?
+    private let manufacturerId: UInt16 = 0xB1C7 // 'bitchat' magic
+
     // MARK: - Service Control
     func startServices() {
-        // TODO: Implement scanning and advertising using WinRT APIs
+        setupScanning()
+        startAdvertising()
+    }
+
+    private func setupScanning() {
+        watcher = Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcher()
+        watcher?.scanningMode = .active
+
+        _ = watcher?.addReceived { [weak self] sender, args in
+            guard let self = self else { return }
+            for md in args.advertisement.manufacturerData {
+                if md.companyId == self.manufacturerId,
+                   let buffer = Data(from: md.data),
+                   let text = String(data: buffer, encoding: .utf8) {
+                    self.handleAdvertisement(text)
+                }
+            }
+        }
+
+        watcher?.start()
+    }
+
+    private func startAdvertising() {
+        let adv = Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisement()
+        let md = Windows.Devices.Bluetooth.Advertisement.BluetoothLEManufacturerData()
+        md.companyId = manufacturerId
+        let hello = "HELLO:\(myPeerID)"
+        md.data = hello.data(using: .utf8)?.toBuffer() ?? IBuffer()
+        _ = adv.manufacturerData.append(md)
+        publisher = Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementPublisher(advertisement: adv)
+        publisher?.start()
+    }
+
+    private func handleAdvertisement(_ text: String) {
+        if text.hasPrefix("HELLO:" ) {
+            let peer = String(text.dropFirst(6))
+            if peer != myPeerID {
+                delegate?.didConnectToPeer(peer)
+            }
+        } else if text.hasPrefix("MSG:" ) {
+            let content = String(text.dropFirst(4))
+            let message = BitchatMessage(sender: peerIDFromString(text), content: content, timestamp: Date(), isRelay: false)
+            delegate?.didReceiveMessage(message)
+        }
+    }
+
+    private func peerIDFromString(_ string: String) -> String {
+        // naive extraction of peer id
+        if let range = string.range(of: "|") {
+            return String(string[..<range.lowerBound])
+        }
+        return "unknown"
     }
 
     // MARK: - Messaging
@@ -63,6 +121,25 @@ class WindowsBluetoothMeshService: NSObject, MeshServiceProtocol {
 
     func getPeerRSSI() -> [String : NSNumber] { [:] }
 
-    func getFingerprint(for peerID: String) -> String? { nil }
+func getFingerprint(for peerID: String) -> String? { nil }
+}
+
+// MARK: - IBuffer helpers
+fileprivate extension Data {
+    init?(from buffer: Windows.Storage.Streams.IBuffer?) {
+        guard let buffer = buffer else { return nil }
+        let length = Int(buffer.Length)
+        self.init(count: length)
+        _ = self.withUnsafeMutableBytes { ptr in
+            memcpy(ptr.baseAddress, buffer.bufferPointer, length)
+        }
+    }
+
+    func toBuffer() -> Windows.Storage.Streams.IBuffer {
+        var data = self
+        return data.withUnsafeMutableBytes { ptr in
+            Windows.Storage.Streams.Buffer(bytes: ptr.baseAddress!, capacity: UInt32(count))
+        }
+    }
 }
 #endif

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -193,7 +193,19 @@ class ChatViewModel: ObservableObject {
             object: nil
         )
         #elseif os(Windows)
-        // Windows placeholder - integrate WinUI lifecycle events here
+        if let app = try? Windows.UI.Xaml.Application.Current {
+            _ = try? app.add_Suspending { [weak self] _, _ in
+                self?.appWillResignActive()
+            }
+            _ = try? app.add_Resuming { [weak self] _ in
+                self?.appDidBecomeActive()
+            }
+        }
+        if let window = try? Windows.UI.Xaml.Window.Current {
+            _ = try? window.add_Closed { [weak self] _, _ in
+                self?.appWillTerminate()
+            }
+        }
         #endif
     }
     

--- a/bitchat/WindowsInterop.swift
+++ b/bitchat/WindowsInterop.swift
@@ -1,0 +1,34 @@
+#if os(Windows)
+import Foundation
+
+private var sharedViewModel: ChatViewModel?
+
+@_cdecl("Bitchat_Initialize")
+public func Bitchat_Initialize() {
+    sharedViewModel = ChatViewModel()
+}
+
+@_cdecl("Bitchat_Shutdown")
+public func Bitchat_Shutdown() {
+    sharedViewModel?.applicationWillTerminate()
+    sharedViewModel = nil
+}
+
+@_cdecl("Bitchat_SendMessage")
+public func Bitchat_SendMessage(_ cString: UnsafePointer<CChar>) {
+    guard let text = String(validatingUTF8: cString ?? "") else { return }
+    sharedViewModel?.sendMessage(text)
+}
+
+@_cdecl("Bitchat_SetNickname")
+public func Bitchat_SetNickname(_ cString: UnsafePointer<CChar>) {
+    guard let text = String(validatingUTF8: cString ?? "") else { return }
+    sharedViewModel?.nickname = text
+}
+
+@_cdecl("Bitchat_JoinChannel")
+public func Bitchat_JoinChannel(_ cString: UnsafePointer<CChar>) {
+    guard let name = String(validatingUTF8: cString ?? "") else { return }
+    _ = sharedViewModel?.joinChannel(name)
+}
+#endif


### PR DESCRIPTION
## Summary
- flesh out `WindowsBluetoothMeshService` with basic WinRT advertisement logic
- hook up WinUI lifecycle events in `ChatViewModel`
- expose C-callable functions for C# via `WindowsInterop.swift`
- document Windows example and link from README
- add `WinUIExample` minimal project demonstrating P/Invoke usage

## Testing
- `swift build` *(fails: no such module 'CryptoKit')*
- `swift test` *(fails: no such module 'CryptoKit')*

------
https://chatgpt.com/codex/tasks/task_b_68771fabc4e8833281245834c33e7367