### PR TITLE
Expand WinUI demo

### DIFF
--- a/WinUIExample/App.xaml.cs
+++ b/WinUIExample/App.xaml.cs
@@ -8,10 +8,18 @@ namespace WinUIExample
         [DllImport("bitchat.dll", CallingConvention = CallingConvention.Cdecl)]
         private static extern void Bitchat_Initialize();
 
+        [DllImport("bitchat.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void Bitchat_Shutdown();
+
         public App()
         {
             this.InitializeComponent();
             Bitchat_Initialize();
+        }
+
+        protected override void OnExit() {
+            Bitchat_Shutdown();
+            base.OnExit();
         }
     }
 }

--- a/WinUIExample/MainWindow.xaml
+++ b/WinUIExample/MainWindow.xaml
@@ -3,8 +3,12 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="BitChat" Height="300" Width="300">
-    <StackPanel Margin="20">
-        <TextBox x:Name="MessageBox"/>
-        <Button Content="Send" Click="OnSend" Margin="0,10,0,0"/>
+    <StackPanel Margin="20" Spacing="10">
+        <TextBlock x:Name="ConnectionState" Margin="0,0,0,10"/>
+        <ListView x:Name="Messages" Height="200"/>
+        <StackPanel Orientation="Horizontal" Spacing="10">
+            <TextBox x:Name="MessageBox" Width="200"/>
+            <Button Content="Send" Click="OnSend"/>
+        </StackPanel>
     </StackPanel>
 </Window>

--- a/WinUIExample/MainWindow.xaml.cs
+++ b/WinUIExample/MainWindow.xaml.cs
@@ -1,6 +1,9 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Collections.ObjectModel;
+using Microsoft.UI.Dispatching;
 
 namespace WinUIExample
 {
@@ -9,15 +12,65 @@ namespace WinUIExample
         [DllImport("bitchat.dll", CallingConvention = CallingConvention.Cdecl)]
         private static extern void Bitchat_SendMessage(string text);
 
+        [DllImport("bitchat.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr Bitchat_GetMessagesJSON();
+
+        [DllImport("bitchat.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void Bitchat_FreeCString(IntPtr ptr);
+
+        [DllImport("bitchat.dll", CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        private static extern bool Bitchat_IsConnected();
+
+        private readonly DispatcherQueueTimer _timer;
+        private readonly ObservableCollection<string> _messageItems = new();
+
         public MainWindow()
         {
             this.InitializeComponent();
+            Messages.ItemsSource = _messageItems;
+
+            _timer = DispatcherQueue.CreateTimer();
+            _timer.Interval = TimeSpan.FromSeconds(1);
+            _timer.Tick += (_, _) => RefreshData();
+            _timer.Start();
         }
 
         private void OnSend(object sender, RoutedEventArgs e)
         {
             Bitchat_SendMessage(MessageBox.Text);
             MessageBox.Text = string.Empty;
+        }
+
+        private void RefreshData()
+        {
+            IntPtr ptr = Bitchat_GetMessagesJSON();
+            if (ptr != IntPtr.Zero)
+            {
+                string json = Marshal.PtrToStringUTF8(ptr) ?? "";
+                Bitchat_FreeCString(ptr);
+                try
+                {
+                    var messages = JsonSerializer.Deserialize<List<Message>>(json);
+                    if (messages != null)
+                    {
+                        _messageItems.Clear();
+                        foreach (var m in messages)
+                        {
+                            _messageItems.Add($"{m.sender}: {m.content}");
+                        }
+                    }
+                }
+                catch { }
+            }
+
+            ConnectionState.Text = Bitchat_IsConnected() ? "Connected" : "Not Connected";
+        }
+
+        private class Message
+        {
+            public string sender { get; set; } = "";
+            public string content { get; set; } = "";
         }
     }
 }

--- a/WinUIExample/README.md
+++ b/WinUIExample/README.md
@@ -1,7 +1,9 @@
 # WinUI Example
 
-This folder contains a minimal WinUI 3 front end that calls the Swift
-`ChatViewModel` via P/Invoke.
+This folder contains a WinUI 3 front end that calls the Swift
+`ChatViewModel` via P/Invoke. The app now polls the Swift layer for
+messages and connection status so you can see chats appear in real
+time.
 
 Build steps:
 1. Build the Swift library in `Release` mode on Windows:

--- a/WinUIExample/WinUIExample.csproj
+++ b/WinUIExample/WinUIExample.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <UseWinUI>true</UseWinUI>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 </Project>

--- a/bitchat/WindowsInterop.swift
+++ b/bitchat/WindowsInterop.swift
@@ -31,4 +31,26 @@ public func Bitchat_JoinChannel(_ cString: UnsafePointer<CChar>) {
     guard let name = String(validatingUTF8: cString ?? "") else { return }
     _ = sharedViewModel?.joinChannel(name)
 }
+
+@_cdecl("Bitchat_GetMessagesJSON")
+public func Bitchat_GetMessagesJSON() -> UnsafeMutablePointer<CChar>? {
+    guard let viewModel = sharedViewModel else { return nil }
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    guard let data = try? encoder.encode(viewModel.messages) else { return nil }
+    let jsonString = String(data: data, encoding: .utf8) ?? ""
+    return strdup(jsonString)
+}
+
+@_cdecl("Bitchat_IsConnected")
+public func Bitchat_IsConnected() -> Bool {
+    return sharedViewModel?.isConnected ?? false
+}
+
+@_cdecl("Bitchat_FreeCString")
+public func Bitchat_FreeCString(_ ptr: UnsafeMutablePointer<CChar>?) {
+    if let ptr = ptr {
+        free(ptr)
+    }
+}
 #endif


### PR DESCRIPTION
## Summary
- show a message list and connection state in WinUI frontend
- expose message JSON and connection status to C# via P/Invoke
- hook up timer-based refresh of messages in the sample
- ensure Windows-targeting builds and update docs

## Testing
- `dotnet build WinUIExample/WinUIExample.csproj` *(fails: Controls namespace not found)*
- `swift test` *(fails: no such module 'CryptoKit')*

------
https://chatgpt.com/codex/tasks/task_b_68772f3245ac83329672f4db216353aa